### PR TITLE
conformer_naive支持更多的激活函数

### DIFF
--- a/diffusion/naive_v2/model_conformer_naive.py
+++ b/diffusion/naive_v2/model_conformer_naive.py
@@ -149,7 +149,8 @@ class ConformerConvModule(nn.Module):
             kernel_size=31,
             dropout=0.,
             use_norm=False,
-            use_doubleswish=False,
+            activation=nn.SiLU(),  # nn.SiLU() / nn.ReLU() / nn.PReLU(512) 'dim=512'
+            use_doubleswish=False, # if activation=nn.SiLU()
             conv_model_type='mode1',
     ):
         super().__init__()
@@ -175,7 +176,7 @@ class ConformerConvModule(nn.Module):
                 nn.Conv1d(dim, inner_dim * 2, 1),
                 nn.GLU(dim=1),
                 nn.Conv1d(inner_dim, inner_dim, kernel_size=kernel_size, padding=padding[0], groups=inner_dim),
-                nn.SiLU(),
+                activation,
                 _doubleswish,
                 nn.Conv1d(inner_dim, dim, 1),
                 Transpose((1, 2)),
@@ -188,7 +189,7 @@ class ConformerConvModule(nn.Module):
                 nn.Conv1d(dim, dim * 2, 1),
                 nn.GLU(dim=1),
                 nn.Conv1d(dim, dim, kernel_size=kernel_size, padding=padding[0], groups=dim),
-                nn.SiLU(),
+                activation,
                 _doubleswish,
                 nn.Conv1d(dim, dim, 1),
                 Transpose((1, 2)),


### PR DESCRIPTION
如题，在多次测试中发现，conformer的最后一个激活函数对生成结果存在影响，conformer原版使用的Swish会造成音染 测试后发现，该激活函数的选择会影响生成结果的风格
目前可能的最优解是PReLU，在diffsinger-lynxnet和ddsp-svc上均有可能的提升表现

具体的解释性研究可见：https://mp.weixin.qq.com/s/2WrEh3wHzYE6TCKuw_laLw