### PR TITLE
Replace PySimpleGUI with FreeSimpleGUI

### DIFF
--- a/gui_realtime.py
+++ b/gui_realtime.py
@@ -1,4 +1,4 @@
-import PySimpleGUI as sg
+import FreeSimpleGUI as sg
 import sounddevice as sd
 import torch, librosa, threading, pickle
 import numpy as np

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ torchfcpe
 tqdm
 transformers
 wave
-pysimplegui
+FreeSimpleGUI
 sounddevice
 gradio
 faiss-cpu


### PR DESCRIPTION
PySimpleGUI is paid now, we can just use FreeSimpleGUI as a drop in replacement.